### PR TITLE
docs: clearer install paths, and a PR rule for the release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -8,17 +8,35 @@ description: Cut a PingMate release — tag, watch the build, publish the DMG an
 A release is a tag push. Everything else follows from it, except the cask, which is updated by hand
 in a second repository.
 
+**Never push to `main` directly — in either repo.** Every change, including a one-line cask bump,
+goes on a branch and through a pull request. Tags are the only thing pushed straight to the remote,
+and only after the PR they build on has been merged.
+
 - App repo: `kikudjira/pingmate` (this one)
 - Tap repo: `kikudjira/homebrew-pingmate`, working copy at `/Users/kikudjira/github/homebrew-pingmate`
 
 There is nothing to bump in the source. `MARKETING_VERSION` is injected from the tag name and
 `CURRENT_PROJECT_VERSION` from the run number, so the only place a version is decided is the tag.
 
-## 1. Preflight
+## 1. Land the changes through a PR
+
+Whatever is going into the release lives on a branch:
 
 ```sh
-git -C . status --porcelain      # must be empty
-git -C . log --oneline origin/main..HEAD   # must be empty — the tag builds what is on the remote
+git checkout -b <branch>
+git commit ...
+git push -u origin <branch>
+gh pr create --base main --title "..." --body "..."
+```
+
+Hand the diff over for review before opening the PR, and let the author merge it. Only then tag.
+
+## 2. Preflight
+
+```sh
+git checkout main && git pull
+git status --porcelain                     # must be empty
+git log --oneline origin/main..HEAD        # must be empty — the tag builds what is on the remote
 ```
 
 Build once locally before tagging anything. A red CI run on a tag is annoying to undo, because the
@@ -33,7 +51,7 @@ Confirm the app still launches and pings, and remember to `pkill -x PingMate` be
 local build — the copy from `/Applications` is usually already in the menu bar and they share a
 `UserDefaults` domain.
 
-## 2. Tag
+## 3. Tag
 
 Semver, `v` prefix. Patch for fixes, minor for features.
 
@@ -42,7 +60,7 @@ git tag -a v<version> -m "PingMate <version>"
 git push origin v<version>
 ```
 
-## 3. Watch the run
+## 4. Watch the run
 
 ```sh
 gh run list -R kikudjira/pingmate --limit 1
@@ -58,7 +76,7 @@ If the run fails, fix forward and re-tag:
 git tag -d v<version> && git push origin :refs/tags/v<version>
 ```
 
-## 4. Bump the cask by hand
+## 5. Bump the cask by hand
 
 The workflow cannot push to the tap — `GITHUB_TOKEN` is scoped to this repo — so it only prints
 what changed. **Never copy the sha256 from a local build**: CI produces its own DMG and the hash
@@ -76,14 +94,21 @@ Then in `/Users/kikudjira/github/homebrew-pingmate/Casks/pingmate.rb` update the
   sha256 "<hash from the released DMG>"
 ```
 
+The tap gets the same treatment as the app repo — branch, PR, merge. A one-line bump is still a
+pull request:
+
 ```sh
 cd /Users/kikudjira/github/homebrew-pingmate
 brew style Casks/pingmate.rb        # must be clean
+git checkout -b cask-<version>
 git commit -am "chore: cask -> <version>"
-git push origin main
+git push -u origin cask-<version>
+gh pr create --base main --title "chore: cask -> <version>" --body "..."
 ```
 
-## 5. Verify the published artefact
+Until that PR is merged, `brew install` still serves the previous version.
+
+## 6. Verify the published artefact
 
 ```sh
 brew fetch --cask kikudjira/pingmate/pingmate   # checksum must match

--- a/README.md
+++ b/README.md
@@ -30,23 +30,37 @@ A native macOS menu bar app, written in Swift and SwiftUI.
 
 ## Install
 
-```sh
-brew install --cask kikudjira/pingmate/pingmate
-```
+Two ways. Both end with PingMate in `/Applications`.
 
-The tap is added for you. Use the full name — with the short `pingmate`, Homebrew refuses to load a cask from a tap you haven't trusted, and you'd need `brew trust kikudjira/pingmate` first.
+### 📦 Option 1 — Download the DMG
 
-Or grab the DMG from the [latest release](https://github.com/kikudjira/pingmate/releases/latest) and drag PingMate to Applications — then read the next bit, because macOS is about to be dramatic.
+**1.** Download `PingMate-<version>.dmg` from the [**latest release**](https://github.com/kikudjira/pingmate/releases/latest).
 
-## "PingMate can't be opened because Apple cannot check it"
+**2.** Open it and drag **PingMate** into **Applications**.
 
-It's fine — it's unsigned. One command fixes it for good:
+**3.** Clear the quarantine flag — one command, once:
 
 ```sh
 xattr -dr com.apple.quarantine /Applications/PingMate.app
 ```
 
-Or open **System Settings → Privacy & Security** and hit **Open Anyway**. The Homebrew cask does this for you.
+**4.** Launch it. The dot appears in the menu bar; there is no Dock icon and no window.
+
+> **Why step 3?** The app isn't signed with a paid Apple certificate, so macOS quarantines the download and says *"PingMate can't be opened because Apple cannot check it for malicious software."* The command above removes the flag. If you'd rather not use a terminal: try to open the app, then go to **System Settings → Privacy & Security** and hit **Open Anyway**.
+
+### 🍺 Option 2 — Homebrew
+
+```sh
+brew install --cask kikudjira/pingmate/pingmate
+```
+
+That's the whole thing — the tap is added for you and the quarantine flag is cleared automatically. Upgrades later:
+
+```sh
+brew upgrade --cask pingmate
+```
+
+> **Use the full name.** With the short `brew install --cask pingmate`, Homebrew refuses to load a cask from a tap you haven't trusted and you'd need `brew trust kikudjira/pingmate` first.
 
 ## Using it
 


### PR DESCRIPTION
Two documentation changes.

## README: two install paths, DMG first

The DMG route used to be one trailing sentence after the Homebrew block, with the quarantine fix stranded in a section below it — so anyone following it hit the Gatekeeper error before reading the fix.

Now both routes are headed options:

- **📦 Option 1 — Download the DMG**: four numbered steps, with `xattr -dr com.apple.quarantine` inline as step 3 and the explanation quoted directly underneath.
- **🍺 Option 2 — Homebrew**: the one-liner, plus `brew upgrade --cask pingmate`, which was missing entirely.

## Release skill: everything goes through a PR

`.claude/skills/release/SKILL.md` now states up front that nothing is pushed to `main` in either repo. Tags are the only exception, and only after the PR they build on is merged.

This also fixes a contradiction the skill shipped with: the cask-bump step told you to `git push origin main` in the tap repo. It now branches and opens a PR there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)