### PR TITLE
fix: login item state must come from the system

### DIFF
--- a/PingMate/PingMate/Services/SettingsStorage.swift
+++ b/PingMate/PingMate/Services/SettingsStorage.swift
@@ -28,9 +28,36 @@ class SettingsStorage: ObservableObject {
     private var appliedLoginState: Bool
 
     init() {
-        let loaded = Self.loadSettings()
+        var loaded = Self.loadSettings()
+
+        // The system owns this setting, not us. A login item can be removed in System Settings,
+        // survive an app deletion in our own defaults, or fail to register in the first place —
+        // and a stored `true` that the system disagrees with used to jam the toggle in both
+        // directions: enabling was skipped as already-applied, disabling threw and rolled back.
+        let registered = Self.isRegisteredAsLoginItem
+        if loaded.startAtLogin != registered {
+            Log.settings.info("Login item state disagreed with the system; using the system's \(registered)")
+            loaded.startAtLogin = registered
+        }
+
         settings = loaded
-        appliedLoginState = loaded.startAtLogin
+        appliedLoginState = registered
+        persist()
+    }
+
+    private static var isRegisteredAsLoginItem: Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+
+    /// Re-reads the system's view before the user can act on ours. `SMAppService` can be changed
+    /// from System Settings at any time, with nothing to tell the app about it.
+    func syncLoginItemState() {
+        let registered = Self.isRegisteredAsLoginItem
+        appliedLoginState = registered
+        guard settings.startAtLogin != registered else { return }
+        Log.settings.info("Login item changed outside the app; now \(registered)")
+        settings.startAtLogin = registered
+        persist()
     }
 
     private static func loadSettings() -> Settings {
@@ -85,11 +112,11 @@ class SettingsStorage: ObservableObject {
         guard !defaults.bool(forKey: loginPromptKey) else { return false }
         // A login item can already exist from an earlier install: don't ask about a setting
         // that is visibly already on.
-        guard SMAppService.mainApp.status != .enabled else {
+        guard !Self.isRegisteredAsLoginItem else {
             markLoginItemAsked()
             return false
         }
-        return !settings.startAtLogin
+        return true
     }
 
     func markLoginItemAsked() {
@@ -119,6 +146,14 @@ class SettingsStorage: ObservableObject {
     }
 
     private func updateLoginItem(enabled: Bool) throws {
+        // Asking for the state it is already in is not a failure. Unregistering an item the
+        // system has never heard of throws, which is how a stale `true` used to become a toggle
+        // that could not be switched off.
+        guard enabled != Self.isRegisteredAsLoginItem else {
+            Log.settings.info("Login item already \(enabled ? "registered" : "unregistered")")
+            return
+        }
+
         if enabled {
             try SMAppService.mainApp.register()
             Log.settings.info("Registered for login item")

--- a/PingMate/PingMate/Views/SettingsTabView.swift
+++ b/PingMate/PingMate/Views/SettingsTabView.swift
@@ -202,6 +202,12 @@ struct SettingsTabView: View {
                     .labelsHidden()
                     .toggleStyle(.switch)
                     .onChange(of: editedSettings.startAtLogin) { _, _ in autoSave() }
+                    // Storage re-reads the system every time this window opens; the form holds
+                    // its own draft and would otherwise keep showing a value the system dropped.
+                    .onChange(of: storage.settings.startAtLogin) { _, actual in
+                        guard editedSettings.startAtLogin != actual else { return }
+                        editedSettings.startAtLogin = actual
+                    }
             }
 
             if let saveError {

--- a/PingMate/PingMate/Views/SettingsWindowController.swift
+++ b/PingMate/PingMate/Views/SettingsWindowController.swift
@@ -14,6 +14,9 @@ class SettingsWindowController: NSObject {
     }
 
     func showWindow() {
+        // The Login Items pane may have been used since the form was last open.
+        settingsStorage.syncLoginItemState()
+
         if let window = window {
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)


### PR DESCRIPTION
Found while testing 1.0.1 on a clean install: the **Start at Login** switch showed *on*, clicking it did nothing, and System Settings had no login item at all.

## What was wrong

`UserDefaults` survives deleting the app, and the Login Items pane can be edited at any time — so the stored `startAtLogin` outlives the thing it claims to describe. Once the two disagreed, the toggle was dead in both directions:

- **turning it on** hit `guard settings.startAtLogin != appliedLoginState` and returned early — the code believed it was already registered, so `register()` was never called;
- **turning it off** called `unregister()` on an item the system had never heard of, which throws; the error path rolled the value straight back, so the switch snapped to where it started.

## Fix

`SMAppService` is the source of truth:

- storage reconciles against it in `init`, and again on every `showWindow()` of Settings, persisting the correction;
- asking for a state that is already in place is a no-op, not a throw;
- the Settings form follows `storage.settings.startAtLogin` instead of keeping a draft the system has since contradicted;
- the first-launch prompt now triggers on "system reports no login item and we have not asked", without consulting the stored value.

## Verified

- Launching with a stale `startAtLogin = true` and no login item present: reconciled to `false` and persisted.
- First-run prompt appears, and confirming it registers successfully — `SMAppService.register()` does not reject an ad-hoc signed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)